### PR TITLE
Merging all the latest code from Gitcorp aem-markdown-importer 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,17 +118,17 @@
      <dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
 		    <artifactId>flexmark</artifactId>
-		    <version>0.12.3</version>
+		    <version>0.28.34</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
 		    <artifactId>flexmark-util</artifactId>
-		    <version>0.12.3</version>
+		    <version>0.28.34</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
 		    <artifactId>flexmark-ext-tables</artifactId>
-		    <version>0.12.3</version>
+		    <version>0.28.34</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
@@ -138,18 +138,23 @@
 		<dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
 		    <artifactId>flexmark-ext-autolink</artifactId>
-		    <version>0.12.3</version>
+		    <version>0.28.34</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
 		    <artifactId>flexmark-ext-gfm-strikethrough</artifactId>
-		    <version>0.12.3</version>
+		    <version>0.28.34</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.vladsch.flexmark</groupId>
 		    <artifactId>flexmark-ext-anchorlink</artifactId>
-		    <version>0.12.3</version>
-			</dependency>
+		    <version>0.28.34</version>
+		</dependency>
+		<dependency>
+		    <groupId>com.vladsch.flexmark</groupId>
+		    <artifactId>flexmark-ext-attributes</artifactId>
+		    <version>0.28.34</version>
+		</dependency>
 		<dependency>
           <groupId>org.jsoup</groupId>
           <artifactId>jsoup</artifactId>
@@ -165,11 +170,7 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
         </dependency>
-        <dependency>
-		    <groupId>commons-io</groupId>
-		    <artifactId>commons-io</artifactId>
-		    <version>2.5</version>
-		</dependency>
+        
 		<dependency>
 		    <groupId>io.wcm.tooling.commons</groupId>
 		    <artifactId>io.wcm.tooling.commons.content-package-builder</artifactId>

--- a/src/main/java/io/adobe/udp/markdownimporter/BranchRootInfo.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/BranchRootInfo.java
@@ -31,7 +31,7 @@ public class BranchRootInfo {
 		this.documentationRootPath = documentationRootPath;
 		this.rootGithubFile = rooPath;
 		this.rootPath = io.adobe.udp.markdownimporter.utils.IONodeUtils.stripFromExtension(rooPath);
-		this.commonPrefix = commonPrefix;
+		this.commonPrefix = StringUtils.equals(commonPrefix, "/") ? "" : commonPrefix;
 		this.first = first;
 		this.branchPageName = extractName();
 		this.branch = branch;

--- a/src/main/java/io/adobe/udp/markdownimporter/GithubMarkdownImporter.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/GithubMarkdownImporter.java
@@ -82,7 +82,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 					BranchRootInfo branchRootInfo = BranchRootInfo.createBranchRootInfo(config.getRootPath(), configPages, githubData.getRepositoryBranch(),
 							allFiles, first, hasPages);
 					String branchPath = IONodeUtils.getBranchPageName(config.getRootPath(), branchRootInfo.getBranchPageName() + "_" + githubData.getRepositoryBranch());
-					Set<String> files = getFiles(branchPath, configPages, githubData, configPages, branchRootInfo, githubLinkService);
+					Set<String> files = getFiles(branchPath, configPages, githubData, configPages, branchRootInfo, githubLinkService, config);
 					branchSuccess = createBranchPage(config.getRootPath(), githubData, branchRootInfo, hasPages, githubLinkService, config, allFiles);
 					files.remove(branchRootInfo.getRootPath() + GithubConstants.MARKDOWN_EXTENSION);
 					pageSuccess = saveGithubPages(branchPath, files,  githubData,  branchRootInfo, config, allFiles);
@@ -104,12 +104,12 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 				hasPages);
 		String readmeFileUrl;
 		if(hasPages) {
-			readmeFileUrl = githubLinkService.mapPathToUrl(rootInfo.getRootPath() + GithubConstants.MARKDOWN_EXTENSION, githubData);			
+			readmeFileUrl = githubLinkService.mapPathToUrl(rootInfo.getRootPath() + GithubConstants.MARKDOWN_EXTENSION, githubData, config);			
 		} else {
 			String getReadmeApiUrl = githubLinkService.getReadmeUrl(githubData);
-			readmeFileUrl = GithubRequests.getFileUrl(getReadmeApiUrl, githubData.getToken());
+			readmeFileUrl = GithubRequests.getFileUrl(getReadmeApiUrl, githubData.getToken(), config.getRetries());
 		}
-		InputStreamReader reader = saveMarkdownFile(branchPage, addCacheKiller(readmeFileUrl));
+		InputStreamReader reader = saveMarkdownFile(branchPage, addCacheKiller(readmeFileUrl), config.getRetries());
 		List<String> imagesList = new ArrayList<String>();
 		String pageUrl = githubLinkService.getFileBlobUrl(githubData, rootInfo.getRootPath());
 		GithubHostedImagePrefixer urlPrefixer = createUrlPrefixer(branchPage + "/" + GithubConstants.IMAGES, githubData,
@@ -122,7 +122,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 			pageData.setTitle(IONodeUtils.extractName(branchPage));
 		}
         this.pages.put(branchPage, pageData);
-		collectImages(branchPage, githubData, imagesList,"", images);
+		collectImages(branchPage, githubData, imagesList,"", images, config);
 //		setImported(branchPage, githubData, rootInfo.getRootGithubFile());
 
 //		return success;
@@ -131,14 +131,14 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 	}
 //
 	private void collectImages(String rootPage, GithubData githubData,
-			List<String> images, String filePath, Map<String, File> imagesMap) throws RepositoryException, IOException {
+			List<String> images, String filePath, Map<String, File> imagesMap,InputConfig config) throws RepositoryException, IOException {
 		Map<String, String> pathToUrl = new HashMap<String, String>();
 		if(images != null && images.size() > 0) {
 			new File(rootPage + "/images").mkdirs();
 		}
 		for(String path : images) {
 			String rawPath = IONodeUtils.removeParams(path);
-			pathToUrl.put(GithubConstants.IMAGES + rawPath, getImageUrl(rawPath, githubData, filePath));
+			pathToUrl.put(GithubConstants.IMAGES + rawPath, getImageUrl(rawPath, githubData, filePath, config));
 		}
 		for(Map.Entry<String, String> pathEntry : pathToUrl.entrySet()) {
 			saveImage(rootPage, pathEntry.getKey(), pathEntry.getValue(), imagesMap);
@@ -146,12 +146,12 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		
 	}
 
-	private String getImageUrl(String path, GithubData githubData, String filePath) throws MalformedURLException, RepositoryException {
+	private String getImageUrl(String path, GithubData githubData, String filePath, InputConfig config) throws MalformedURLException, RepositoryException {
 			if(path.startsWith("/")) {
 				return githubData.getGithubUrl() + path;
 			} else {
 				String imagePath = getImagePath(filePath) + path;
-				return githubLinkService.mapPathToUrl(imagePath, githubData);
+				return githubLinkService.mapPathToUrl(imagePath, githubData, config);
 			}
 	}
 	
@@ -200,11 +200,11 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		}
 	
 	private Set<String> getFiles(String branchPath, List<String> paths, GithubData githubData, List<String> configPages, 
-			BranchRootInfo rootInfo, GithubLinkService githubLinkService) throws MalformedURLException{
+			BranchRootInfo rootInfo, GithubLinkService githubLinkService, InputConfig config) throws MalformedURLException{
 		Set<String> filesToImport = new TreeSet<String>();
 			for(String startPath : paths) {
 				if(startPath.contains("*")) {
-					addGlobbedPaths(filesToImport, githubLinkService.getPathInRepository(startPath.replaceAll("\\*", ""), githubData), githubData, githubLinkService);
+					addGlobbedPaths(filesToImport, githubLinkService.getPathInRepository(startPath.replaceAll("\\*", ""), githubData), githubData, githubLinkService, config);
 				} else {
 					filesToImport.add(githubLinkService.getPathInRepository(startPath, githubData));
 				}
@@ -217,7 +217,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		if(!config.isLocalCheckout()) {
 			for(String startPath : paths) {
 				if(startPath.contains("*")) {
-					addGlobbedPaths(files, githubLinkService.getPathInRepository(startPath.replaceAll("\\*", ""), githubData), githubData, githubLinkService);
+					addGlobbedPaths(files, githubLinkService.getPathInRepository(startPath.replaceAll("\\*", ""), githubData), githubData, githubLinkService, config);
 				} else {
 					files.add(githubLinkService.getPathInRepository(startPath, githubData));
 				}
@@ -225,7 +225,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		} else {
 			for(String startPath : paths) {
 				if(startPath.contains("*")) {
-					addGlobbedPaths(files, githubLinkService.getPathInRepository(startPath.replaceAll("\\*", ""), githubData), githubData, githubLinkService);
+					addGlobbedPaths(files, githubLinkService.getPathInRepository(startPath.replaceAll("\\*", ""), githubData), githubData, githubLinkService, config);
 				} else {
 					files.add(githubLinkService.getPathInRepository(startPath, githubData));
 				}
@@ -235,11 +235,11 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 	}
 
 	private void addGlobbedPaths(Set<String> filesToImport, String startPath,
-			GithubData githubData, GithubLinkService githubLinkService) {
+			GithubData githubData, GithubLinkService githubLinkService, InputConfig config) {
 		try {
 			String gitTreeRequest = githubLinkService.getGithubTreeUrl(startPath, githubData);
-			JSONObject treeResponse = GithubRequests.executeTreeRequest(gitTreeRequest, githubData.getToken(), true);
-			collectPagesFromTree(treeResponse, githubData, filesToImport, IONodeUtils.stripFromExtension(startPath));
+			JSONObject treeResponse = GithubRequests.executeTreeRequest(gitTreeRequest, githubData.getToken(), true, config.getRetries());
+			collectPagesFromTree(treeResponse, githubData, filesToImport, IONodeUtils.stripFromExtension(startPath), config);
 		} catch (Exception e) {
 			System.out.println(e.getMessage());
 		}
@@ -247,7 +247,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 	}
 
 	private void collectPagesFromTree(JSONObject treeResponse,
-			GithubData githubData, Set<String> filesToImport, String startPath) {
+			GithubData githubData, Set<String> filesToImport, String startPath, InputConfig config) {
 		try {
 			if(treeResponse.getBoolean("truncated")) {
 				JSONArray tree = treeResponse.getJSONArray("tree");
@@ -257,8 +257,8 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 					if(isEligibleToIterate(entry)) {
 						String url = entry.getString(GithubConstants.URL);
 						String path = startPath + "/" + entry.getString("path");
-						JSONObject jsonResponse = GithubRequests.executeTreeRequest(url, githubData.getToken(), true);
-						collectPagesFromTree(jsonResponse, githubData, filesToImport, path);
+						JSONObject jsonResponse = GithubRequests.executeTreeRequest(url, githubData.getToken(), true, config.getRetries());
+						collectPagesFromTree(jsonResponse, githubData, filesToImport, path, config);
 					}
 				}	
 			} else {
@@ -329,9 +329,9 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		internalFilePath = IONodeUtils.removeFirstSlash(internalFilePath);
 		String parentPath = IONodeUtils.replaceDotsInPath(rootPath + "/" + internalFilePath.substring(0, internalFilePath.lastIndexOf("/") + 1));
 		String pageName = IONodeUtils.replaceDotsInPath(internalFilePath.substring(internalFilePath.lastIndexOf("/") + 1));
-		String url = githubLinkService.mapPathToUrl(githubFilePath, githubData);
+		String url = githubLinkService.mapPathToUrl(githubFilePath, githubData, config);
 		String filePath = parentPath + IONodeUtils.trimName(pageName);
-		InputStreamReader reader = saveMarkdownFile(filePath, addCacheKiller(url));
+		InputStreamReader reader = saveMarkdownFile(filePath, addCacheKiller(url), config.getRetries());
 		FolderPageData folderPageData = new FolderPageData(config.getPageResourceType(), config.getPageTemplate(), config.getDesignPath());
 		IONodeUtils.addPlaceHolderTemplate(rootPath, filePath, githubFilePath, files, pages, config);
 		List<String> imagesList = new ArrayList<String>();
@@ -344,7 +344,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		if(StringUtils.isBlank(pageData.getTitle())) {
 			pageData.setTitle(IONodeUtils.removeMDExtensionFromPath(pageName));
 		}
-		collectImages(filePath, githubData, imagesList, githubFilePath, this.images);
+		collectImages(filePath, githubData, imagesList, githubFilePath, this.images, config);
 		this.pages.put(filePath, pageData);
 //		setImported(filePath, githubData, githubFilePath);
 		return true;
@@ -355,11 +355,18 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		return new GithubHostedImagePrefixer(urlPrefix, githubData, rootInfo, pagePath, fileBlobUrl, allFiles, originalFilePath);
 	}
 
-	private InputStreamReader saveMarkdownFile(String pagePath, String url) throws IOException {
-		URL file = new URL(url);
-//		File markdownFile = new File(pagePath + "/_jcr_content/markdown");
-//		FileUtils.copyURLToFile(file, markdownFile);
-		return new InputStreamReader(file.openStream());
+	private InputStreamReader saveMarkdownFile(String pagePath, String url, int retries) throws IOException {
+		int tries = 0;
+		while(tries < retries) { 
+			try {
+				URL file = new URL(url);
+				return new InputStreamReader(file.openStream());
+			} catch (IOException e) {
+				System.out.println("Connection error, trying to reconnect");
+				tries++;
+			}
+		}
+		return null;
 	}
 
 	private String addCacheKiller(String url) {

--- a/src/main/java/io/adobe/udp/markdownimporter/GithubMarkdownImporter.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/GithubMarkdownImporter.java
@@ -120,7 +120,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 			pageData.setTitle(IONodeUtils.extractName(branchPage));
 		}
         this.pages.put(branchPage, pageData);
-		collectImages(branchPage, githubData, imagesList,"", images, config);
+		collectImages(branchPage, githubData, imagesList, rootInfo.getRootPath(), images, config);
 //		setImported(branchPage, githubData, rootInfo.getRootGithubFile());
 
 //		return success;

--- a/src/main/java/io/adobe/udp/markdownimporter/GithubMarkdownImporter.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/GithubMarkdownImporter.java
@@ -37,8 +37,6 @@ import org.apache.sling.commons.json.JSONObject;
 
 public class GithubMarkdownImporter implements MarkdownImporter {
 
-	private static final String PAGES_PROPERTY = "pages";
-
 	private MarkdownParserService markdownParserService;
 	
 	private GithubLinkService githubLinkService;	
@@ -104,7 +102,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 				hasPages);
 		String readmeFileUrl;
 		if(hasPages) {
-			readmeFileUrl = githubLinkService.mapPathToUrl(rootInfo.getRootPath() + GithubConstants.MARKDOWN_EXTENSION, githubData, config);			
+			readmeFileUrl = githubLinkService.mapPathToUrl(IONodeUtils.escapeUrlWhitespaces(rootInfo.getRootPath() + GithubConstants.MARKDOWN_EXTENSION), githubData, config);			
 		} else {
 			String getReadmeApiUrl = githubLinkService.getReadmeUrl(githubData);
 			readmeFileUrl = GithubRequests.getFileUrl(getReadmeApiUrl, githubData.getToken(), config.getRetries());
@@ -329,7 +327,7 @@ public class GithubMarkdownImporter implements MarkdownImporter {
 		internalFilePath = IONodeUtils.removeFirstSlash(internalFilePath);
 		String parentPath = IONodeUtils.replaceDotsInPath(rootPath + "/" + internalFilePath.substring(0, internalFilePath.lastIndexOf("/") + 1));
 		String pageName = IONodeUtils.replaceDotsInPath(internalFilePath.substring(internalFilePath.lastIndexOf("/") + 1));
-		String url = githubLinkService.mapPathToUrl(githubFilePath, githubData, config);
+		String url = githubLinkService.mapPathToUrl(IONodeUtils.escapeUrlWhitespaces(githubFilePath), githubData, config);
 		String filePath = parentPath + IONodeUtils.trimName(pageName);
 		InputStreamReader reader = saveMarkdownFile(filePath, addCacheKiller(url), config.getRetries());
 		FolderPageData folderPageData = new FolderPageData(config.getPageResourceType(), config.getPageTemplate(), config.getDesignPath());

--- a/src/main/java/io/adobe/udp/markdownimporter/Importer.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/Importer.java
@@ -13,6 +13,7 @@ import io.adobe.udp.markdownimporter.services.GithubLinkService;
 import io.adobe.udp.markdownimporter.services.GithubLinkServiceImpl;
 import io.adobe.udp.markdownimporter.services.MarkdownParserService;
 import io.adobe.udp.markdownimporter.services.MarkdownParserServiceImpl;
+import io.adobe.udp.markdownimporter.utils.IONodeUtils;
 import io.wcm.tooling.commons.contentpackagebuilder.ContentPackage;
 import io.wcm.tooling.commons.contentpackagebuilder.ContentPackageBuilder;
 
@@ -90,7 +91,7 @@ public class Importer
 	private static Map<String, Map<String, Object>> toContent(Map<String, PageData> pages) {
 		Map<String, Map<String, Object>> content = new TreeMap<String, Map<String, Object>>();
 		for(Map.Entry<String, PageData> entry : pages.entrySet()) {
-			content.put(entry.getKey(), entry.getValue().toContent());
+			content.put(IONodeUtils.escapePath(entry.getKey()), entry.getValue().toContent());
 		}
 		return content;
 	}

--- a/src/main/java/io/adobe/udp/markdownimporter/Importer.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/Importer.java
@@ -82,7 +82,7 @@ public class Importer
     			contentPackage.addPage(entry.getKey(), entry.getValue());
     		}
     		for(Map.Entry<String, File> entry : images.entrySet()) {
-    			contentPackage.addFile(entry.getKey(), entry.getValue(), "image/gif");
+    			contentPackage.addFile(entry.getKey(), entry.getValue(), "application/octet-stream");
     		}
     	}
 

--- a/src/main/java/io/adobe/udp/markdownimporter/InputConfig.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/InputConfig.java
@@ -13,11 +13,14 @@ import java.util.Map.Entry;
 
 public class InputConfig {
 	
+	private static final int DEFAULT_RETRIES_NUMBER = 1;
+	
 	private String githubUrl;
 	private String githubContentUrl;
 	private String githubApiUrl;
 	private String apiToken;
 	private int commitTime;
+	private int retries;
 	private boolean privateRepository;
 	
 	private String repositoryUrl;
@@ -176,6 +179,15 @@ public class InputConfig {
 	}
 	public void setTemplateMappings(Map<String, String> templateMappings) {
 		this.templateMappings = templateMappings;
+	}
+	public int getRetries() {
+		if(this.retries > 0) {
+			return retries;
+		}
+		return DEFAULT_RETRIES_NUMBER;
+	}
+	public void setRetries(int retries) {
+		this.retries = retries;
 	}
 	public TemplateMapper getTemplateMapper() {
 		if(templateMapper == null) {

--- a/src/main/java/io/adobe/udp/markdownimporter/RootPageData.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/RootPageData.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.apache.sling.jcr.resource.JcrResourceConstants;
 
+import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.NameConstants;
 
 public class RootPageData implements PageData {
@@ -30,6 +31,7 @@ public class RootPageData implements PageData {
 		result.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, inputConfig.getRootPageResourceType());
 		result.put(NameConstants.PN_DESIGN_PATH, inputConfig.getDesignPath());
 		result.put(NameConstants.PN_TEMPLATE, inputConfig.getRootTemplate());
+		result.put(JcrConstants.JCR_TITLE, inputConfig.getRootTitle());
 		result.put("imported", true);
 		result.put("isFolder", true);
 		result.put("isDocumentationRoot", "true");

--- a/src/main/java/io/adobe/udp/markdownimporter/WorkdirMarkdownImporter.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/WorkdirMarkdownImporter.java
@@ -151,7 +151,7 @@ public class WorkdirMarkdownImporter implements MarkdownImporter  {
 				return githubData.getGithubUrl() + path;
 			} else {
 				String imagePath = getImagePath(filePath) + path;
-				return githubLinkService.mapPathToUrl(imagePath, githubData);
+				return githubLinkService.mapPathToUrl(imagePath, githubData, config);
 			}
 	}
 	

--- a/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/AssetCollector.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/AssetCollector.java
@@ -1,0 +1,47 @@
+package io.adobe.udp.markdownimporter.flexmarkExtensions;
+
+import io.adobe.udp.markdownimporter.utils.Constants;
+
+import java.util.List;
+
+import com.vladsch.flexmark.ast.Link;
+import com.vladsch.flexmark.ast.Node;
+import com.vladsch.flexmark.ast.NodeVisitor;
+import com.vladsch.flexmark.ast.VisitHandler;
+import com.vladsch.flexmark.ast.Visitor;
+
+public class AssetCollector {
+	
+	private static final String EXTENSIONS = ".*(pdf|xls|xlsx|doc|docx)$";
+	List<String> urls ;
+
+	   
+    NodeVisitor visitor = new NodeVisitor(
+            new VisitHandler<Link>(Link.class, new Visitor<Link>() {
+                @Override
+                public void visit(Link link) {
+                    AssetCollector.this.visit(link);
+                }
+            })
+    );
+    
+    public AssetCollector(List<String> urls) {
+    	this.urls = urls;
+    }
+
+    public void visit(Link link) {
+    	if(!link.getUrl().startsWith(Constants.HTTP_PREFIX) && !link.getUrl().startsWith(Constants.HTTPS_PREFIX)
+    			&& link.getUrl().toString().matches(EXTENSIONS)) {
+    		this.urls.add(link.getUrl().toString());
+    	}
+        visitor.visitChildren(link);
+    }
+    
+    public List<String> getUrls() {
+    	return this.urls;
+    }
+    
+    public void collectAssets(Node document) {
+    	this.visitor.visitChildren(document);
+    }
+}

--- a/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/GithubHostedImagePrefixer.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/GithubHostedImagePrefixer.java
@@ -40,7 +40,7 @@ public class GithubHostedImagePrefixer implements UrlPrefixer {
 
 	@Override
 	public String prefix(String path) {
-		if(!path.startsWith(Constants.HTTP_PREFIX) && !path.startsWith(Constants.HTTPS_PREFIX) && !path.startsWith("#")) {
+		if(!path.startsWith(Constants.HTTP_PREFIX) && !path.startsWith(Constants.HTTPS_PREFIX) && !path.startsWith("#") && !path.startsWith("mailto:")) {
 			if(StringUtils.isNotBlank(path) && path.endsWith(GithubConstants.MARKDOWN_EXTENSION)) {
 				return rewritePathToMarkdown(path);
 			}

--- a/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/GithubHostedImagePrefixer.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/GithubHostedImagePrefixer.java
@@ -98,7 +98,11 @@ public class GithubHostedImagePrefixer implements UrlPrefixer {
 	}
 	
 	private String getParentPage(String page) {
-		return page.substring(0, page.lastIndexOf("/"));
+		if(page.lastIndexOf("/") > 0) {
+			return page.substring(0, page.lastIndexOf("/"));
+		}
+		return "";
+		
 	}
 	private String fileGithubUrl(String path) {
 		if(isAbsolute(path)) {

--- a/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/GithubHostedImagePrefixer.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/flexmarkExtensions/GithubHostedImagePrefixer.java
@@ -41,7 +41,7 @@ public class GithubHostedImagePrefixer implements UrlPrefixer {
 	@Override
 	public String prefix(String path) {
 		if(!path.startsWith(Constants.HTTP_PREFIX) && !path.startsWith(Constants.HTTPS_PREFIX) && !path.startsWith("#") && !path.startsWith("mailto:")) {
-			if(StringUtils.isNotBlank(path) && path.endsWith(GithubConstants.MARKDOWN_EXTENSION)) {
+			if(StringUtils.isNotBlank(path) && (path.endsWith(GithubConstants.MARKDOWN_EXTENSION) || path.contains("#") || path.endsWith(".html"))) {
 				return rewritePathToMarkdown(path);
 			}
 			return urlPrefix + IONodeUtils.removeFirstSlash(path);
@@ -56,10 +56,10 @@ public class GithubHostedImagePrefixer implements UrlPrefixer {
 			internalPath = path.replaceFirst(githubData.getBlobPrefix(), "");
 		}
 		internalPath = IONodeUtils.removeFirstSlash(branchRootInfo.getInternalPath(internalPath));
-		if(allFiles.contains(originalLinkPath)) {
-			return IONodeUtils.replaceDotsInPath(aemFilePath(internalPath)) + ".html";
+		if(allFiles.contains(originalLinkPath) || allFiles.contains("/" + originalLinkPath)) {
+			return IONodeUtils.escapeUrlWhitespaces(IONodeUtils.replaceDotsInPath(aemFilePath(internalPath))) + ".html";
 		}
-		return fileGithubUrl(path);
+		return IONodeUtils.escapeUrlWhitespaces(fileGithubUrl(path));
 		
 	}
 
@@ -101,7 +101,7 @@ public class GithubHostedImagePrefixer implements UrlPrefixer {
 		if(path.startsWith("./")) {
 			return githubPageUrl + "/." +  path;
 		} else {
-			return githubPageUrl + "/" + path;
+			return getParentPage(githubPageUrl) + "/" + path;
 		}
 	}
 
@@ -109,4 +109,5 @@ public class GithubHostedImagePrefixer implements UrlPrefixer {
 		return path.startsWith("/");
 	}
 
+	
 }

--- a/src/main/java/io/adobe/udp/markdownimporter/services/GithubLinkService.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/services/GithubLinkService.java
@@ -26,7 +26,7 @@ public interface GithubLinkService {
 	
 	String getContentUrl(String repositoryUrl, String ref);
 	
-	String mapPathToUrl(String path, GithubData githubData) throws MalformedURLException;
+	String mapPathToUrl(String path, GithubData githubData, InputConfig config) throws MalformedURLException;
 	
 	String getGithubTreeUrl(String path, GithubData githubData) throws MalformedURLException;
 	

--- a/src/main/java/io/adobe/udp/markdownimporter/services/GithubLinkServiceImpl.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/services/GithubLinkServiceImpl.java
@@ -84,7 +84,7 @@ public class GithubLinkServiceImpl implements GithubLinkService {
 		return null;
 	}
 
-	public String mapPathToUrl(String path, GithubData githubData) throws MalformedURLException {
+	public String mapPathToUrl(String path, GithubData githubData, InputConfig config) throws MalformedURLException {
 		Joiner joiner = Joiner.on("/").skipNulls();
 		if(!githubData.isCorp()) {
 			if(!path.startsWith(Constants.HTTP_PREFIX) && !path.startsWith(Constants.HTTPS_PREFIX)) {
@@ -99,7 +99,7 @@ public class GithubLinkServiceImpl implements GithubLinkService {
 			String contentsUrl = Constants.HTTPS_PREFIX + githubData.getApiUrl() + GithubConstants.REPOS + "/" +
 					githubData.getRepositoryOwner() + "/" + githubData.getReposiotryName() + GithubConstants.CONTENTS + 
 					"/" + path + "?ref=" + githubData.getRepositoryBranch();
-			return GithubRequests.getFileUrl(contentsUrl, githubData.getToken());
+			return GithubRequests.getFileUrl(contentsUrl, githubData.getToken(), config.getRetries());
 		}
 	}
 

--- a/src/main/java/io/adobe/udp/markdownimporter/services/MarkdownParserServiceImpl.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/services/MarkdownParserServiceImpl.java
@@ -7,6 +7,7 @@
 package io.adobe.udp.markdownimporter.services;
 
 import io.adobe.udp.markdownimporter.MarkdownPageData;
+import io.adobe.udp.markdownimporter.flexmarkExtensions.AssetCollector;
 import io.adobe.udp.markdownimporter.flexmarkExtensions.GithubHostedImagePrefixer;
 import io.adobe.udp.markdownimporter.flexmarkExtensions.ImageUrlExtension;
 import io.adobe.udp.markdownimporter.flexmarkExtensions.ImageVisitor;
@@ -58,7 +59,7 @@ public class MarkdownParserServiceImpl implements MarkdownParserService {
 			HtmlRenderer renderer = HtmlRenderer.builder(options).build();
 			String content = IOUtils.toString(file);
 	        com.vladsch.flexmark.ast.Node document = parser.parse(content);
-	        collectImages(document, urls);
+	        collectImagesAndAssets(document, urls);
 //	        System.out.println(renderer.render(document));
 	        convertDocumentToComponents(document, pageData, renderer, parser);
 	        return pageData;
@@ -69,9 +70,11 @@ public class MarkdownParserServiceImpl implements MarkdownParserService {
 		
 	}
 		
-	private void collectImages(com.vladsch.flexmark.ast.Node document, List<String> urls) {
+	private void collectImagesAndAssets(com.vladsch.flexmark.ast.Node document, List<String> urls) {
 		ImageVisitor visitor = new ImageVisitor(urls);
+		AssetCollector collector = new AssetCollector(urls);
         visitor.collectImages(document);
+        collector.collectAssets(document);
 	}
 
 	private void convertDocumentToComponents(

--- a/src/main/java/io/adobe/udp/markdownimporter/services/MarkdownParserServiceImpl.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/services/MarkdownParserServiceImpl.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.IOUtils;
 import com.vladsch.flexmark.ast.Heading;
 import com.vladsch.flexmark.ast.util.HeadingCollectingVisitor;
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension;
+import com.vladsch.flexmark.ext.attributes.AttributesExtension;
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
 import com.vladsch.flexmark.ext.front.matter.YamlFrontMatterBlock;
 import com.vladsch.flexmark.ext.front.matter.YamlFrontMatterExtension;
@@ -47,7 +48,7 @@ public class MarkdownParserServiceImpl implements MarkdownParserService {
 			new HashMap<String, String>();
 			 MutableDataHolder options = new MutableDataSet();
 	        options.set(Parser.EXTENSIONS, Arrays.asList(TablesExtension.create(), ImageUrlExtension.create(), YamlFrontMatterExtension.create(),
-	        	StrikethroughExtension.create(), AutolinkExtension.create(), UdpUrlExtension.create(), AnchorLinkExtension.create()));
+	        	StrikethroughExtension.create(), AutolinkExtension.create(), UdpUrlExtension.create(), AnchorLinkExtension.create(), AttributesExtension.create()));
 	        options.set(ImageUrlExtension.URL_CHANGER, urlPrefixer);
 	        options.set(TablesExtension.COLUMN_SPANS, false)
 	        .set(TablesExtension.APPEND_MISSING_COLUMNS, true)

--- a/src/main/java/io/adobe/udp/markdownimporter/utils/GithubConstants.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/utils/GithubConstants.java
@@ -47,7 +47,7 @@ public class GithubConstants {
 	public static final String AUTHOR = "author";
 	public static final String CONTENTS = "/contents";
 	public static final String AUTOPUBLISH = "autopublish";
-	public static final String IMAGES = "images/";
+	public static final String IMAGES = "jcr:content/images/";
 	public static final String IMPORT_FAILED = "failed";
 	public static final String BRANCH_FILE = "branchFile";
 	public static final String COMMON_PREFIX = "commonPrefix";

--- a/src/main/java/io/adobe/udp/markdownimporter/utils/GithubRequests.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/utils/GithubRequests.java
@@ -12,6 +12,8 @@ import io.adobe.udp.markdownimporter.rest.RestClientResponse;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -110,7 +112,8 @@ public class GithubRequests {
 	}
 	
 	private static Object execute(String url, String token, Map<String, String> params, int retries) {
-		RestClient restClient = params == null ? new RestClient(url) : new RestClient(url, params);
+		String normalizedUrl = normalize(url);
+		RestClient restClient = params == null ? new RestClient(normalizedUrl) : new RestClient(normalizedUrl, params);
 		if(StringUtils.isNotBlank(token)) {
 			restClient.addHeader("Authorization", "token " + token);
 		}
@@ -119,7 +122,7 @@ public class GithubRequests {
 		while(tries < retries)
 		try {
 			response = restClient.doGet();
-			System.out.println("Connected to: " + url + "status: " + response.getStatus());
+			System.out.println("Connected to: " + normalizedUrl + "status: " + response.getStatus());
 			if(response.getJson().trim().startsWith("{")) {
 				return new JSONObject(response.getJson());
 			} else {
@@ -130,5 +133,16 @@ public class GithubRequests {
 			tries++;
 		}
 		return null;
+	}
+	
+	private static String normalize(String path) {
+		URI uri;
+		try {
+			uri = new URI(path);
+		} catch (URISyntaxException e) {
+			System.out.println(e.getMessage());
+			return path;
+		}
+		return uri.normalize().toString();
 	}
 }

--- a/src/main/java/io/adobe/udp/markdownimporter/utils/IONodeUtils.java
+++ b/src/main/java/io/adobe/udp/markdownimporter/utils/IONodeUtils.java
@@ -25,6 +25,17 @@ public class IONodeUtils {
 		return path.replace(".", "_");
 	}
 	
+	/**
+	 * replaces illegal sling path characters with underscores (spaces and dots)
+	 * @param path
+	 * @return
+	 */
+	public static String escapePath(String path) {
+		return path.replace(".", "_").replace(" ", "_")
+				.replace("%20", "_")
+				.replace(" ", "_");
+	}
+	
 	public static String trimName(String name) {
 		if(name.startsWith("/")) {
 			return name.substring(1);
@@ -148,5 +159,15 @@ public class IONodeUtils {
 			return StringUtils.removeEnd(path, "_md");
 		}
 		return path;
+	}
+	
+	/**
+	 * replaces whitespaces with %20 for url
+	 */
+	public static String escapeUrlWhitespaces(String path) {
+		if(StringUtils.isBlank(path)) {
+			return path;
+		}
+		return path.replace(" ", "%20");
 	}
 }


### PR DESCRIPTION
This PR is for issue #…

Following things have changed:
- Updates the version of flex mark used in standalone importer to 0.28.34. 
- Improved scrolling experience in Imported API/Developer Documentation
- Better formatting for the lists and nested lists in Imported API docs
- Improved connection communication between standalone importer and AEM 
- Better Image Alignment, formatting and rendering from markdown sources by standalone importer
- Email, white spaces and HTML links handled better in imported documentation 