### PR TITLE
Update various dependencies that do not introduce any breaking changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.4</version>
+			<version>3.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.adobe.aem</groupId>
@@ -218,7 +218,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>19.0</version>
+			<version>28.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
@@ -228,7 +228,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
+			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.wcm.tooling.commons</groupId>


### PR DESCRIPTION
Following things have changed:
- Update Apache Commons Lang from 3.4 to 3.9
- Update Google Guava from 19.0 to 28.1 (and also switch to the JRE-variant)
- Update Commons IO from 2.5 to 2.6

Someone maybe could take a look at Guava and tell me whether its better to use the -android or the -jre variant